### PR TITLE
chore: add schedule to build new nightly images

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,6 +1,8 @@
 name: Build and publish container image
 
 on:
+  schedule:
+    - cron: "42 1 * * *"
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
scheduled runs only run on the default branch:

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule