### PR TITLE
feat(repo.txt): Add https://gitlab.com/swiss-armed-forces

### DIFF
--- a/repo-scanner/repos.txt
+++ b/repo-scanner/repos.txt
@@ -18,6 +18,7 @@ https://github.com/MeteoSwiss
 https://github.com/opendata-swiss
 https://github.com/SFOE
 https://github.com/Swiss-Armed-Forces
+https://gitlab.com/swiss-armed-forces
 https://github.com/swiss-territorial-data-lab
 https://github.com/SwissFederalArchives
 https://github.com/swisstopo


### PR DESCRIPTION
This commit updates the list of repositories scanned by the `repo-scanner` to include the Swiss Armed Forces repositories on GitLab.

Currently, the `oss-catalog/repo-scanner` only scans repositories listed on **GitHub**. This causes an issue for projects like `Swiss-Armed-Forces/Loom` which are mirrored from **GitLab to GitHub**.

The scanner checks the `publiccode.yml` file on GitHub, but the file's declared canonical URL points to the GitLab repository. This mismatch triggers an error:
> `BAD publiccode.yml: declared url (...) and actual publiccode.yml location URL (...) are not in the same repo: '//gitlab.com/...' vs '//github.com/...'`

By additionally including our GitLab repositories in the scanner's source list (`repos.txt`), we aim to:
1.  Ensure these mirrored or GitLab-native repositories are properly discovered.
2.  Allow the scanner to find the `publiccode.yml` in its canonical, declared location (on GitLab) for projects where the GitHub version is a mirror, resolving the URL mismatch error.

---

Note on GitLab Support: This change assumes the current `publicode.yaml` crawler can successfully handle fetching and processing files from GitLab URLs. If not, further work may be required in the scanner logic itself.