### PR TITLE
chore: upgrade github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - "main"
+      - "chore/upgrade-github-actions"
     tags:
       - "v*.*.*"
 
@@ -26,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install pnpm
         uses: pnpm/action-setup@v6
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
           cache: pnpm
@@ -58,10 +59,10 @@ jobs:
           API_BASEURL: https://oss-catalog-api.ocp.cloudscale.puzzle.ch/v1
           GIT_COMMIT_HASH: ${{ github.sha }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./client/dist
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - "main"
-      - "chore/upgrade-github-actions"
     tags:
       - "v*.*.*"
 


### PR DESCRIPTION
Upgrades GitHub Actions to their latest major versions:

actions/checkout v6 → v7
actions/setup-node v6 → v7
actions/upload-pages-artifact v3 → v5
actions/deploy-pages v4 → v5
No functional changes to the workflow logic.