### PR TITLE
fix: filter organisations using the combobox

### DIFF
--- a/client/src/components/Combobox.tsx
+++ b/client/src/components/Combobox.tsx
@@ -107,9 +107,7 @@ export function Combobox({ groups, lang, onChange }: ComboboxProps) {
           >
             <div className="vs__dropdown-toggle">
               <div className="vs__selected-options vs--single">
-                <span className="vs__selected">
-                  {buttonLabel || "\u00a0"}
-                </span>
+                <span className="vs__selected">{buttonLabel || "\u00a0"}</span>
               </div>
               <div className="vs__actions">
                 {/* actions like clear or spinner are not used here */}
@@ -124,7 +122,11 @@ export function Combobox({ groups, lang, onChange }: ComboboxProps) {
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-[min(64rem,90vw)] p-0">
-        <Command>
+        <Command
+          filter={(value, search) =>
+            value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0
+          }
+        >
           <CommandInput />
           {values.length > 0 && (
             <div className="flex flex-wrap gap-2 px-3 py-2 v-select">

--- a/client/src/components/SoftwareFilters.tsx
+++ b/client/src/components/SoftwareFilters.tsx
@@ -32,7 +32,9 @@ export function SoftwareFilters({ lang, organisations }: Props) {
     unit: Organisation | Department,
     suffix: Organisation["alternativeName"] | Department["abbreviation"],
   ) => {
-    return `${unit.name[lang] || unit.name.de || ""} ${suffix ? ` (${suffix[lang] || suffix.de})` : ""}`;
+    const name = unit.name[lang] || unit.name.de || "";
+    const suffixText = suffix?.[lang] || suffix?.de;
+    return `${name}${suffixText ? ` (${suffixText})` : ""}`.trim();
   };
 
   const groupedOptions = useMemo(() => {

--- a/client/src/components/SoftwareFilters.tsx
+++ b/client/src/components/SoftwareFilters.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import { Combobox } from "@/components/Combobox.tsx";
-import { useTranslations } from "../i18n/utils";
+import { useTranslations } from "@/i18n/utils";
 import { CANTON_URI_PREFIX, selectedOrganisations } from "@/stores/filters.ts";
 
 export type Locale = "en" | "de" | "fr" | "it";
@@ -25,54 +25,29 @@ type Props = {
   organisations: Department[];
 };
 
-export function SoftwareFilters({
-  lang,
-  organisations,
-}: Props) {
-  const [query] = useState("");
-  const [_open, setOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement | null>(null);
+export function SoftwareFilters({ lang, organisations }: Props) {
   const t = useTranslations(lang);
 
-  const toLabel = (unit: Organisation | Department, suffix: Organisation['alternativeName'] | Department['abbreviation']) => {
+  const toLabel = (
+    unit: Organisation | Department,
+    suffix: Organisation["alternativeName"] | Department["abbreviation"],
+  ) => {
     return `${unit.name[lang] || unit.name.de || ""} ${suffix ? ` (${suffix[lang] || suffix.de})` : ""}`;
   };
 
   const groupedOptions = useMemo(() => {
-    const q = query.trim().toLowerCase();
     return organisations
       .filter((departement) => !departement.id.startsWith(CANTON_URI_PREFIX))
-      .map((departement) => {
-        const filteredOrganisations = departement.organisations.filter(
-          (organisation) => {
-            if (!q) return true;
-            return (organisation.name[lang] || organisation.name.de || "")
-              .toLowerCase()
-              .includes(q);
-          },
-        );
-        return {
-          id: departement.id,
-          label: toLabel(departement, departement.abbreviation),
-          organisations: filteredOrganisations.map((organisation) => ({
-            value: organisation.id,
-            label: toLabel(organisation, organisation.alternativeName),
-          })),
-        };
-      })
+      .map((departement) => ({
+        id: departement.id,
+        label: toLabel(departement, departement.abbreviation),
+        organisations: departement.organisations.map((organisation) => ({
+          value: organisation.id,
+          label: toLabel(organisation, organisation.alternativeName),
+        })),
+      }))
       .filter((d) => d.organisations.length > 0);
-  }, [organisations, query, lang]);
-
-  useEffect(() => {
-    function onClickOutside(e: MouseEvent) {
-      if (!dropdownRef.current) return;
-      if (!dropdownRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", onClickOutside);
-    return () => document.removeEventListener("mousedown", onClickOutside);
-  }, []);
+  }, [organisations, lang]);
 
   return (
     <>

--- a/client/src/pages/[locale]/index.astro
+++ b/client/src/pages/[locale]/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
-import { type Lang, useTranslations, toFullLocale } from "@/i18n/utils";
+import { type Lang, useTranslations } from "@/i18n/utils";
 import organisations from "@/data/organisations.json";
 import SoftwareCatalogIsland from "@/components/SoftwareCatalogIsland";
 import { type PubliccodeYml, type Software } from "@/lib/software";
@@ -34,17 +34,6 @@ softwares.sort((a, b) => {
   const uriB = b.publiccode?.organisation?.uri || "";
   return uriA.localeCompare(uriB);
 });
-
-const dateLocale = toFullLocale(lang);
-const buildDate = new Date();
-const buildDateFormatted = `${buildDate.toLocaleDateString(dateLocale, {
-  day: "2-digit",
-  month: "2-digit",
-  year: "numeric",
-})} ${buildDate.toLocaleTimeString(dateLocale, {
-  hour: "2-digit",
-  minute: "2-digit",
-})}`;
 
 export async function getStaticPaths() {
   return Object.keys(locales).map((locale) => {


### PR DESCRIPTION
This PR actually contains several bugfixes:
* The combobox to search for organisations was actually broken - it basically showed all entries, regardless of the search term and the combobox now searches for exact (partial) matches. The cdk component in use applied a fuzzy search per default.
* removed the unused variable `buildDateFormatted`
* the toLabel function for the software filter could possible produce "(undefined)" and contain stray whitespaces