### PR TITLE
fix: open drawer when organisation is in the url

### DIFF
--- a/client/src/components/SearchFiltersIsland.tsx
+++ b/client/src/components/SearchFiltersIsland.tsx
@@ -11,6 +11,7 @@ import {
   applyFiltersFromUrl,
   searchTerm,
   organisationType,
+  selectedOrganisations,
   syncFiltersToUrl,
 } from "@/stores/filters";
 import type { Software } from "@/lib/software.ts";
@@ -30,12 +31,21 @@ export default function SearchFiltersIsland({
   const [isOpen, setIsOpen] = useState(false);
   const $searchTerm = useStore(searchTerm);
   const $organisationType = useStore(organisationType);
+  const hasSelectedOrganisations = useStore(selectedOrganisations).length > 0;
 
   useEffect(() => {
     if ($organisationType === "cantons") {
       setIsOpen(false);
     }
   }, [$organisationType]);
+
+  // Organisations can be preselected from the url (e.g. coming from a software
+  // detail page), so reveal the drawer instead of hiding an active filter.
+  useEffect(() => {
+    if (hasSelectedOrganisations) {
+      setIsOpen(true);
+    }
+  }, [hasSelectedOrganisations]);
 
   useEffect(() => {
     applyFiltersFromUrl();


### PR DESCRIPTION
When the user clicks on the organisation url in the software detail page, the organisation filter (drawer) is now open and it is visible to the user that a filter is set.